### PR TITLE
calendar entries

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -5,6 +5,15 @@ theme = "hugo-theme-massively"
 googleanalytics = ""
 disqusShortname = ""
 defaultContentLanguage = "de"
+uglyURLs = true
+
+[outputFormats.HTML]
+# We want the filenames for calendar entries to be title.ics,
+# but we also want the normal html site to have (what Hugo calls) pretty urls.
+# Sadly, Hugo does not provide a way to set the only the calendar URLs to ugly,
+# so we have to set uglyURLs = true globally, and deactivate the setting for html.
+# See https://discourse.gohugo.io/t/individual-filenames-for-output-formats/34163
+noUgly = true
 
 [menu]
   [[menu.main]]

--- a/content/concerts/2022-brunswick-breakdown.md
+++ b/content/concerts/2022-brunswick-breakdown.md
@@ -1,8 +1,13 @@
 ---
 title: "Brunswick Breakdown"
+publishDate: 2022-01-22
 date: 2022-10-22T20:00:00
+location: "KufA Haus"
 draft: true
 image: "images/bg.jpg"
+outputs:
+- html
+- calendar
 ---
 
 ## Das Highlight des Jahres!

--- a/content/concerts/2022-hamburg.md
+++ b/content/concerts/2022-hamburg.md
@@ -1,8 +1,13 @@
 ---
 title: "Hamburg, Komm du Kulturcafé"
+publishDate: 2022-01-22
 date: 2022-04-16T20:00:00
+location:  Kulturcafé Komm du, Hamburg
 draft: true
 image: "images/bg.jpg"
+outputs:
+- html
+- calendar
 ---
 
 Wir freuen uns sehr, am 16.04.2022 um 20:00 im [Komm du Kulturcafé](https://www.komm-du.de/) zu spielen.

--- a/content/concerts/2022-helmstedt.md
+++ b/content/concerts/2022-helmstedt.md
@@ -1,8 +1,13 @@
 ---
 title: "Christopheruskirche in Helmstedt"
+publishDate: 2022-01-22
 date: 2022-04-03T17:00:00
+location: "St. Christopherus Kirche in Helmstedt"
 draft: true
 image: "images/bg.jpg"
+outputs:
+- html
+- calendar
 ---
 
 Unser erstes Konzert, am 3.4. in der Christopheruskirche in Helmstedt.

--- a/layouts/concerts/single.html
+++ b/layouts/concerts/single.html
@@ -1,0 +1,25 @@
+{{ define "main" }}
+	<!-- Post -->
+	<section class="post">
+	  <header class="major">
+		  {{ with .Date }}
+		  <span class="date">{{ time.Format (partial "posts/dateFormat" $) . }}</span>
+		  {{ end }}
+		  <h1>{{ .Title }}</h1>
+                  {{ partial "calendar_link" . }}
+		  <p>{{ .Description }}</p>
+	  </header>
+	  {{ with partial "posts/imgURL" . }}
+	  <div class="image main"><img src="{{ . }}" alt="" /></div>
+	  {{ end }}
+	  
+	  {{ .Content }}
+	  {{ partial "postcustom" . }}
+
+	  {{ partial "posts/tags.html" .}}
+	  
+	  {{ if not .Params.disableComments }}
+	  {{ template "_internal/disqus.html" . }}
+	  {{ end }}
+	</section>
+{{ end }}

--- a/layouts/concerts/single.ics
+++ b/layouts/concerts/single.ics
@@ -1,0 +1,15 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:hugo//bluefate.de//EN
+CALSCALE:GREGORIAN
+METHOD:PUBLISH
+BEGIN:VEVENT
+SUMMARY:{{.Title}}
+DESCRIPTION:{{.Plain}}
+UID:{{dateFormat "20060102T150405" .Date}}@bluefate.de
+DTSTAMP:{{dateFormat "20060102T150405" .PublishDate}}
+DTSTART:{{dateFormat "20060102T150405" .Date}}
+LOCATION:{{with .Params.location}}{{.}}{{else}}TBD{{end}}
+URL:{{.Permalink}}
+END:VEVENT
+END:VCALENDAR

--- a/layouts/partials/calendar_link.html
+++ b/layouts/partials/calendar_link.html
@@ -1,0 +1,6 @@
+<a
+  href="{{ with  .OutputFormats.Get "calendar" -}}{{ .RelPermalink }}{{- end }}"
+  class="icon fa-calendar"
+  title="Kalendereintrag herunterladen"
+>
+</a>

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -25,6 +25,8 @@ collections:
     slug: "{{year}}-{{month}}-{{day}}-{{slug}}"
     fields:
       - {label: "Title", name: "title", widget: "string"}
+      - {label: "Publish Date", name: "publishDate", widget: "datetime"}
       - {label: "Event Date", name: "date", widget: "datetime"}
+      - {label: "Location", name: "location", widget: "string"}
       - {label: "Image", name: "image", widget: "image"}
       - {label: "Body", name: "body", widget: "markdown"}


### PR DESCRIPTION

- generate calendar entries (`title.ics`)
- link to them on the concert page

The position of the link on the concert page is not ideal. @p3tr0sh I'll leave it like that, the layout of that page is bound to change anyway.
