### PR TITLE
Set URL for netlify previews.

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,3 +4,6 @@ command = "hugo --buildDrafts --buildExpired --buildFuture --gc --minify"
 
 [build.environment]
 HUGO_VERSION = "0.88.1"
+
+[context.deploy-preview]
+command = "hugo --buildDrafts --buildExpired --buildFuture --gc --minify --baseURL $DEPLOY_PRIME_URL"


### PR DESCRIPTION
Internal links e.g. generated from the `posts/list.html` template use the `.Permalink` property, which includes the baseURL. For previews, this means the links lead to `www.bluefate.de`, not the preview site. 

Override the baseURL for previews, so that internal links work as expected.